### PR TITLE
mp4 Compilation Fixes

### DIFF
--- a/taglib-1.6.3/taglib/mp4/mp4tag.cpp
+++ b/taglib-1.6.3/taglib/mp4/mp4tag.cpp
@@ -629,28 +629,28 @@ MP4::Tag::composer() const
 		return d->items["\251wrt"].toStringList().toString(", ");
 	return String::null;
 }
-uint  
+TagLib::uint  
 MP4::Tag::totalTracks() const
 {
 	if(d->items.contains("trkn"))
 		return d->items["trkn"].toIntPair().second;
 	return 0;
 }
-uint  
+TagLib::uint  
 MP4::Tag::cdNr() const
 {
 	if(d->items.contains("disk"))
 		return d->items["disk"].toIntPair().first;
 	return 0;
 }
-uint  
+TagLib::uint  
 MP4::Tag::totalCDs() const
 {
 	if(d->items.contains("disk"))
 		return d->items["disk"].toIntPair().second;
 	return 0;	
 }
-uint  
+TagLib::uint  
 MP4::Tag::bpm() const
 {
 	if(d->items.contains("tmpo"))

--- a/taglib-1.6.3/taglib/mp4/mp4tag.cpp
+++ b/taglib-1.6.3/taglib/mp4/mp4tag.cpp
@@ -31,6 +31,7 @@
 
 #include <tdebug.h>
 #include <tstring.h>
+#include <string.h>
 #include "mp4atom.h"
 #include "mp4tag.h"
 #include "id3v1genres.h"

--- a/taglib-1.6.3/taglib/ogg/xiphcomment.cpp
+++ b/taglib-1.6.3/taglib/ogg/xiphcomment.cpp
@@ -119,6 +119,13 @@ TagLib::uint Ogg::XiphComment::track() const
   return 0;
 }
 
+TagLib::uint Ogg::XiphComment::cdNr() const
+{
+  if(!d->fieldListMap["DISCNUMBER"].isEmpty())
+    return d->fieldListMap["DISCNUMBER"].front().toInt();
+  return 0;
+}
+
 void Ogg::XiphComment::setTitle(const String &s)
 {
   addField("TITLE", s);
@@ -160,6 +167,16 @@ void Ogg::XiphComment::setTrack(uint i)
     removeField("TRACKNUMBER");
   else
     addField("TRACKNUMBER", String::number(i));
+}
+
+int Ogg::XiphComment::setCDNr(uint i)
+{
+  if(i == 0)
+    removeField("DISCNUMBER");
+  else
+    addField("DISCNUMBER", String::number(i));
+
+  return 0;
 }
 
 bool Ogg::XiphComment::isEmpty() const

--- a/taglib-1.6.3/taglib/ogg/xiphcomment.cpp
+++ b/taglib-1.6.3/taglib/ogg/xiphcomment.cpp
@@ -126,6 +126,15 @@ TagLib::uint Ogg::XiphComment::cdNr() const
   return 0;
 }
 
+String Ogg::XiphComment::albumArtist() const
+{
+  if(!d->fieldListMap["ALBUMARTIST"].isEmpty())
+    return d->fieldListMap["ALBUMARTIST"].front();
+//  if(!d->fieldListMap["ALBUM ARTIST"].isEmpty())
+//    return d->fieldListMap["ALBUM ARTIST"].front();
+  return String::null;
+}
+
 void Ogg::XiphComment::setTitle(const String &s)
 {
   addField("TITLE", s);
@@ -177,6 +186,12 @@ int Ogg::XiphComment::setCDNr(uint i)
     addField("DISCNUMBER", String::number(i));
 
   return 0;
+}
+
+int Ogg::XiphComment::setAlbumArtist(const String &s)
+{
+  removeField("ALBUM ARTIST");
+  addField("ALBUMARTIST", s);
 }
 
 bool Ogg::XiphComment::isEmpty() const

--- a/taglib-1.6.3/taglib/ogg/xiphcomment.h
+++ b/taglib-1.6.3/taglib/ogg/xiphcomment.h
@@ -87,6 +87,7 @@ namespace TagLib {
       virtual uint year() const;
       virtual uint track() const;
       virtual uint cdNr() const;
+      virtual String albumArtist() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);
@@ -96,6 +97,7 @@ namespace TagLib {
       virtual void setYear(uint i);
       virtual void setTrack(uint i);
       virtual int setCDNr(uint i);
+      virtual int setAlbumArtist(const String &s);
 
       virtual bool isEmpty() const;
 

--- a/taglib-1.6.3/taglib/ogg/xiphcomment.h
+++ b/taglib-1.6.3/taglib/ogg/xiphcomment.h
@@ -86,6 +86,7 @@ namespace TagLib {
       virtual String genre() const;
       virtual uint year() const;
       virtual uint track() const;
+      virtual uint cdNr() const;
 
       virtual void setTitle(const String &s);
       virtual void setArtist(const String &s);
@@ -94,6 +95,7 @@ namespace TagLib {
       virtual void setGenre(const String &s);
       virtual void setYear(uint i);
       virtual void setTrack(uint i);
+      virtual int setCDNr(uint i);
 
       virtual bool isEmpty() const;
 


### PR DESCRIPTION
Hello,

I found two issues with your included patches, so I fixed them in my repo's copy. I did not bother with a .patch file, but git should be able to extract it somehow.

Both of these affect taglib/mp4/mp4tag.cpp and are pretty small.

The first issue had to do with uint fix and the added fields in the mp4 support not having the same fix applied to them.

The second issue was the lack of including string.h to get memcmp. Some systems are okay without this, but at least in newer versions of Fedora this casues problems. I've seen the same issue on some newer versions of Debian but I couldn't test that here.

Anyway, I hope this helps you, and thanks for collecting the patches to add this support. It's very useful to one of my projects.

- avuserow